### PR TITLE
Add HTTPS support with automatic TLS certificates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,7 +351,8 @@
         "nixpkgs": "nixpkgs_2",
         "servant-event-stream": "servant-event-stream",
         "tabler-icons": "tabler-icons",
-        "unionmount": "unionmount"
+        "unionmount": "unionmount",
+        "warp-tls-simple": "warp-tls-simple"
       }
     },
     "servant-event-stream": {
@@ -420,6 +421,22 @@
       "original": {
         "owner": "srid",
         "repo": "unionmount",
+        "type": "github"
+      }
+    },
+    "warp-tls-simple": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758321703,
+        "narHash": "sha256-7/U6UwXuJqWKi2CpNkTjDPO/13Mtof4LwmHbWnf/unU=",
+        "owner": "srid",
+        "repo": "warp-tls-simple",
+        "rev": "bbe9069048f38a04bb45b7adeda9ce84d87f2015",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "warp-tls-simple",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
     servant-event-stream.flake = false;
     tabler-icons.url = "github:juspay/tabler-icons-hs";
     tabler-icons.flake = false;
+    warp-tls-simple.url = "github:srid/warp-tls-simple";
+    warp-tls-simple.flake = false;
   };
 
   outputs = inputs:

--- a/nix/modules/flake/haskell.nix
+++ b/nix/modules/flake/haskell.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     inputs.haskell-flake.flakeModule
+    (inputs.warp-tls-simple + /flake-module.nix)
   ];
   perSystem = { self', lib, ... }: {
     haskellProjects.default = {

--- a/nix/modules/home-manager/imako.nix
+++ b/nix/modules/home-manager/imako.nix
@@ -32,6 +32,12 @@ in
       default = "localhost";
       description = "Host to bind the web server to";
     };
+
+    https = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable HTTPS (TLS certificates auto-generated in vault/.imako)";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -44,7 +50,7 @@ in
 
       Service = {
         Type = "simple";
-        ExecStart = "${cfg.package}/bin/imako ${cfg.vaultDir} --port ${toString cfg.port} --host ${cfg.host}";
+        ExecStart = "${cfg.package}/bin/imako ${cfg.vaultDir} --port ${toString cfg.port} --host ${cfg.host}${optionalString (!cfg.https) " --no-https"}";
       };
 
       Install = {
@@ -63,7 +69,7 @@ in
           (toString cfg.port)
           "--host"
           cfg.host
-        ];
+        ] ++ optionals (!cfg.https) [ "--no-https" ];
         RunAtLoad = true;
         KeepAlive = false;
         StandardOutPath = "${config.home.homeDirectory}/Library/Logs/imako.log";

--- a/packages/imako/imako.cabal
+++ b/packages/imako/imako.cabal
@@ -79,8 +79,11 @@ common shared
     , time
     , unionmount             >=0.3
     , unliftio-core
+    , wai
     , wai-extra
     , wai-middleware-static
+    , warp
+    , warp-tls-simple
     , with-utf8
 
   hs-source-dirs:     src

--- a/packages/imako/src/Imako/CLI.hs
+++ b/packages/imako/src/Imako/CLI.hs
@@ -1,12 +1,15 @@
 module Imako.CLI where
 
+import Network.Wai.Handler.Warp (Port)
+import Network.Wai.Handler.WarpTLS.Simple (TLSConfig, tlsConfigParser)
 import Options.Applicative
 
 -- Define the data structure to hold parsed arguments
 data Options = Options
   { path :: FilePath
-  , port :: Int
-  , host :: String
+  , port :: Port
+  , host :: Text
+  , tlsConfig :: TLSConfig
   }
   deriving stock (Show)
 
@@ -36,6 +39,7 @@ optionsParser =
           <> showDefault
           <> help "Host to bind the web server to"
       )
+    <*> tlsConfigParser
 
 -- Parser info with additional configuration
 opts :: ParserInfo Options


### PR DESCRIPTION
Enables HTTPS by default using warp-tls-simple for automatic self-signed certificate generation. Certificates are stored in `vault/.imako` directory. Users can disable HTTPS with `--no-https` flag or provide custom certificates via `--tls-cert` and `--tls-key` options. The home-manager module also supports the new `https` option (defaults to true).